### PR TITLE
fix: make _uuid4_if_falsy always return str

### DIFF
--- a/clinvar_this/io/tsv.py
+++ b/clinvar_this/io/tsv.py
@@ -172,7 +172,7 @@ def _str_list(val: str, pat: str = r"[;,]") -> typing.List[str]:
         return [x.strip() for x in re.split(pat, val)]
 
 
-def _uuid4_if_falsy(value: typing.Optional[str] = None) -> typing.Union[str]:
+def _uuid4_if_falsy(value: typing.Optional[str] = None) -> str:
     """Return a new UUID4-valued string if ``value`` is falsy."""
     if value:
         return value

--- a/clinvar_this/io/tsv.py
+++ b/clinvar_this/io/tsv.py
@@ -172,12 +172,12 @@ def _str_list(val: str, pat: str = r"[;,]") -> typing.List[str]:
         return [x.strip() for x in re.split(pat, val)]
 
 
-def _uuid4_if_falsy(value: typing.Optional[str] = None) -> typing.Union[str, uuid.UUID]:
-    """Return a new UUID4 if ``value`` is falsy."""
+def _uuid4_if_falsy(value: typing.Optional[str] = None) -> typing.Union[str]:
+    """Return a new UUID4-valued string if ``value`` is falsy."""
     if value:
         return value
     else:
-        return uuid.uuid4()
+        return str(uuid.uuid4())
 
 
 def _today_if_falsy(value: typing.Optional[str] = None) -> str:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved clarity on UUID handling by ensuring functions return UUID-valued strings.

- **Bug Fixes**
	- Enhanced consistency in return types for specific functions.

- **Documentation**
	- Defined default values for `BatchMetadata` fields for better reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->