### PR TITLE
docs: Update usage_cli.rst

### DIFF
--- a/docs/usage_cli.rst
+++ b/docs/usage_cli.rst
@@ -34,7 +34,7 @@ The following figure shows the overall workflow when using clinvar-this.
   You can query the current result with ``clinvar-this batch retrieve``.
   If this does not return yet, try again.
 - Otherwise, you can export the current state of the batch with ``clinvar-this batch export`` to a TSV file.
-- When there are errors, fix the variants to be submitted and re-submit with ``clinvar-this batch submit``.
+- When there are errors, fix the variants to be submitted, re-import (``clinvar-this`` will create a new payload with ``"record_status": "update"`` for each finding) and then re-submit with ``clinvar-this batch submit``.
 - If everything runs to your liking, read out your ClinVar SCV identifier.
 
 Note that the NCBI ClinVar server process runs the checks in several steps.


### PR DESCRIPTION
Added to documentation:
After fixing submission errors, one needs to re-import the TSV file before re-submission.

Maybe also:
Update PNG displayed on https://clinvar-this.readthedocs.io/en/latest/usage_cli.html to show circling back from `fix file content` to `clinvar-this batch import`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the `clinvar-this` command line tool documentation for enhanced clarity on usage and workflow.
	- Expanded the error handling section to emphasize the two-step process of fixing variants and re-importing before re-submission.
	- Improved explanations in the workflow section regarding error handling and NCBI ClinVar server processing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->