### PR TITLE
fix: deal with undefined XRef

### DIFF
--- a/clinvar_data/conversion/__init__.py
+++ b/clinvar_data/conversion/__init__.py
@@ -15,8 +15,8 @@ from clinvar_data.conversion import dict_to_pb
 from clinvar_data.conversion.normalizer import VariationArchiveNormalizer
 from clinvar_data.pbs import clinvar_public
 
-#: Total number of VariantArchive records in ClinVar on 2024-05-24: 2966486.
-TOTAL_RECORDS: int = 3_000_000
+#: Total number of VariantArchive records in ClinVar on 2025-02-18: 3335626.
+TOTAL_RECORDS: int = 3_335_626
 
 
 def convert_variation_archive(json_va: dict) -> clinvar_public.VariationArchive:

--- a/clinvar_data/conversion/__init__.py
+++ b/clinvar_data/conversion/__init__.py
@@ -51,7 +51,7 @@ def convert(
     pb: tqdm.tqdm | None = None
     if show_progress:
         pb = tqdm.tqdm(
-            desc="parsing", unit=" VariationArchive records", smoothing=1.0, total=TOTAL_RECORDS
+            desc="parsing", unit=" VariationArchive records", smoothing=0.001, total=TOTAL_RECORDS
         )
     records_written = 0
     errors = 0

--- a/clinvar_data/conversion/dict_to_pb.py
+++ b/clinvar_data/conversion/dict_to_pb.py
@@ -857,7 +857,9 @@ class ConverterBase:
         if "XRef" not in value:
             pass
         elif isinstance(value.get("XRef", []), list):
-            xrefs = [ConvertXref.xmldict_data_to_pb({"XRef": entry}) for entry in value.get("XRef", [])]
+            xrefs = [
+                ConvertXref.xmldict_data_to_pb({"XRef": entry}) for entry in value.get("XRef", [])
+            ]
         elif isinstance(value.get("XRef", {}), dict):
             xrefs = [ConvertXref.xmldict_data_to_pb({"XRef": value.get("XRef", {})})]
         else:
@@ -3517,7 +3519,9 @@ class ConvertAlleleScv(ConverterBase):
                 for entry in tag_sa.get("XRefList", {}).get("XRef", [])
             ]
         elif isinstance(tag_sa.get("XRefList", {}).get("XRef", {}), dict):
-            xrefs = [ConvertXref.xmldict_data_to_pb({"XRef": tag_sa.get("XRefList", {}).get("XRef", {})})]
+            xrefs = [
+                ConvertXref.xmldict_data_to_pb({"XRef": tag_sa.get("XRefList", {}).get("XRef", {})})
+            ]
         else:
             assert False, f"Invalid type for XRef {tag_sa['XRef']}"
         # parse out comments

--- a/clinvar_data/conversion/dict_to_pb.py
+++ b/clinvar_data/conversion/dict_to_pb.py
@@ -856,10 +856,10 @@ class ConverterBase:
         xrefs: list[Xref] | None = None
         if "XRef" not in value:
             pass
-        elif isinstance(value["XRef"], list):
-            xrefs = [ConvertXref.xmldict_data_to_pb({"XRef": entry}) for entry in value["XRef"]]
-        elif isinstance(value["XRef"], dict):
-            xrefs = [ConvertXref.xmldict_data_to_pb({"XRef": value["XRef"]})]
+        elif isinstance(value.get("XRef", []), list):
+            xrefs = [ConvertXref.xmldict_data_to_pb({"XRef": entry}) for entry in value.get("XRef", [])]
+        elif isinstance(value.get("XRef", {}), dict):
+            xrefs = [ConvertXref.xmldict_data_to_pb({"XRef": value.get("XRef", {})})]
         else:
             assert False, f"Invalid type for XRef {value['XRef']}"
         # parse out comments
@@ -948,8 +948,8 @@ class ConvertXref(ConverterBase):
             The ``Xref`` protobuf.
         """
         assert "XRef" in value
-        assert isinstance(value["XRef"], dict)
-        tag_xref: dict[str, str] = value["XRef"]
+        assert isinstance(value.get("XRef", {}), dict)
+        tag_xref: dict[str, str] = value.get("XRef", {})
         cls.assert_keys(tag_xref, ["@ID", "@DB"])
         if "@Status" in tag_xref:
             status = ConvertStatus.xmldict_data_to_pb(tag_xref["@Status"])
@@ -2417,7 +2417,7 @@ class ConvertGeneralCitations(ConverterBase):
         if "XRef" in tag_function_consequence:
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_function_consequence["XRef"])
+                for entry in cls.ensure_list(tag_function_consequence.get("XRef", []))
             ]
 
         return GeneralCitations(
@@ -2747,7 +2747,7 @@ class ConvertLocation(ConverterBase):
         if "XRef" in tag_location:
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_location["XRef"])
+                for entry in cls.ensure_list(tag_location.get("XRef", []))
             ]
 
         return Location(
@@ -3324,7 +3324,7 @@ class ConvertMethodType(ConverterBase):
         if "XRef" in tag_method:
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_method["XRef"])
+                for entry in cls.ensure_list(tag_method.get("XRef", []))
             ]
         description: str | None = None
         if "Description" in tag_method:
@@ -3400,7 +3400,7 @@ class ConvertAlleleScv(ConverterBase):
         if "XRef" in tag_gene:
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_gene["XRef"])
+                for entry in cls.ensure_list(tag_gene.get("XRef", []))
             ]
         symbol: str | None = None
         if "@Symbol" in tag_gene:
@@ -3509,15 +3509,15 @@ class ConvertAlleleScv(ConverterBase):
             assert False, f"Invalid type for Citation {tag_sa['Citation']}"
         # parse out xrefs
         xrefs: list[Xref] | None = None
-        if "XRefList" not in tag_sa or "XRef" not in tag_sa["XRefList"]:
+        if "XRefList" not in tag_sa or "XRef" not in tag_sa.get("XRefList", {}):
             pass
-        elif isinstance(tag_sa["XRefList"]["XRef"], list):
+        elif isinstance(tag_sa.get("XRefList", {}).get("XRef", []), list):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in tag_sa["XRefList"]["XRef"]
+                for entry in tag_sa.get("XRefList", {}).get("XRef", [])
             ]
-        elif isinstance(tag_sa["XRefList"]["XRef"], dict):
-            xrefs = [ConvertXref.xmldict_data_to_pb({"XRef": tag_sa["XRefList"]["XRef"]})]
+        elif isinstance(tag_sa.get("XRefList", {}).get("XRef", {}), dict):
+            xrefs = [ConvertXref.xmldict_data_to_pb({"XRef": tag_sa.get("XRefList", {}).get("XRef", {})})]
         else:
             assert False, f"Invalid type for XRef {tag_sa['XRef']}"
         # parse out comments
@@ -3628,10 +3628,10 @@ class ConvertHaplotypeScv(ConverterBase):
                 for entry in cls.ensure_list(tag_genotype["CitationList"]["Citation"])
             ]
         xrefs: list[Xref] | None = None
-        if "XRefList" in tag_genotype and "XRef" in tag_genotype["XRefList"]:
+        if "XRefList" in tag_genotype and "XRef" in tag_genotype.get("XRefList", {}):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_genotype["XRefList"]["XRef"])
+                for entry in cls.ensure_list(tag_genotype.get("XRefList", {}).get("XRef", []))
             ]
         comments: list[Comment] | None = None
         if "Comment" in tag_genotype:
@@ -3722,10 +3722,10 @@ class ConvertGenotypeScv(ConverterBase):
                 for entry in cls.ensure_list(tag_genotype["CitationList"]["Citation"])
             ]
         xrefs: list[Xref] | None = None
-        if "XRefList" in tag_genotype and "XRef" in tag_genotype["XRefList"]:
+        if "XRefList" in tag_genotype and "XRef" in tag_genotype.get("XRefList", {}):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_genotype["XRefList"]["XRef"])
+                for entry in cls.ensure_list(tag_genotype.get("XRefList", {}).get("XRef", []))
             ]
         comments: list[Comment] | None = None
         if "Comment" in tag_genotype:
@@ -4395,10 +4395,10 @@ class ConvertAllele(ConverterBase):
                 {"Classifications": tag_allele["Classifications"]}
             )
         xrefs: list[Xref] | None = None
-        if "XRefList" in tag_allele and "XRef" in tag_allele["XRefList"]:
+        if "XRefList" in tag_allele and "XRef" in tag_allele.get("XRefList", {}):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_allele["XRefList"]["XRef"])
+                for entry in cls.ensure_list(tag_allele.get("XRefList", {}).get("XRef", []))
             ]
         comments: list[Comment] | None = None
         if "Comment" in tag_allele:
@@ -4496,10 +4496,10 @@ class ConvertHaplotype(ConverterBase):
                 for entry in cls.ensure_list(tag_haplotype["FunctionalConsequence"])
             ]
         xrefs: list[Xref] | None = None
-        if "XRefList" in tag_haplotype and "XRef" in tag_haplotype["XRefList"]:
+        if "XRefList" in tag_haplotype and "XRef" in tag_haplotype.get("XRefList", {}):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_haplotype["XRefList"]["XRef"])
+                for entry in cls.ensure_list(tag_haplotype.get("XRefList", {}).get("XRef", []))
             ]
         comments: list[Comment] | None = None
         if "Comment" in tag_haplotype:
@@ -4668,10 +4668,10 @@ class ConvertGenotype(ConverterBase):
                 {"Classifications": tag_record["Classifications"]}
             )
         xrefs: list[Xref] | None = None
-        if "XRefList" in tag_record and "XRef" in tag_record["XRefList"]:
+        if "XRefList" in tag_record and "XRef" in tag_record.get("XRefList", {}):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_record["XRefList"]["XRef"])
+                for entry in cls.ensure_list(tag_record.get("XRefList", {}).get("XRef", []))
             ]
         citations: list[Citation] | None = None
         if "CitationList" in tag_record and "Citation" in tag_record["CitationList"]:

--- a/clinvar_data/conversion/dict_to_pb.py
+++ b/clinvar_data/conversion/dict_to_pb.py
@@ -3511,16 +3511,16 @@ class ConvertAlleleScv(ConverterBase):
             assert False, f"Invalid type for Citation {tag_sa['Citation']}"
         # parse out xrefs
         xrefs: list[Xref] | None = None
-        if "XRefList" not in tag_sa or "XRef" not in tag_sa.get("XRefList", {}):
+        if "XRefList" not in tag_sa or "XRef" not in (tag_sa["XRefList"] or {}):
             pass
-        elif isinstance(tag_sa.get("XRefList", {}).get("XRef", []), list):
+        elif isinstance((tag_sa["XRefList"] or {}).get("XRef", []), list):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in tag_sa.get("XRefList", {}).get("XRef", [])
+                for entry in (tag_sa["XRefList"] or {}).get("XRef", [])
             ]
-        elif isinstance(tag_sa.get("XRefList", {}).get("XRef", {}), dict):
+        elif isinstance((tag_sa["XRefList"] or {}).get("XRef", {}), dict):
             xrefs = [
-                ConvertXref.xmldict_data_to_pb({"XRef": tag_sa.get("XRefList", {}).get("XRef", {})})
+                ConvertXref.xmldict_data_to_pb({"XRef": (tag_sa["XRefList"] or {}).get("XRef", {})})
             ]
         else:
             assert False, f"Invalid type for XRef {tag_sa['XRef']}"
@@ -3632,10 +3632,10 @@ class ConvertHaplotypeScv(ConverterBase):
                 for entry in cls.ensure_list(tag_genotype["CitationList"]["Citation"])
             ]
         xrefs: list[Xref] | None = None
-        if "XRefList" in tag_genotype and "XRef" in tag_genotype.get("XRefList", {}):
+        if "XRefList" in tag_genotype and "XRef" in (tag_genotype["XRefList"] or {}):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_genotype.get("XRefList", {}).get("XRef", []))
+                for entry in cls.ensure_list((tag_genotype["XRefList"] or {}).get("XRef", []))
             ]
         comments: list[Comment] | None = None
         if "Comment" in tag_genotype:
@@ -3726,10 +3726,10 @@ class ConvertGenotypeScv(ConverterBase):
                 for entry in cls.ensure_list(tag_genotype["CitationList"]["Citation"])
             ]
         xrefs: list[Xref] | None = None
-        if "XRefList" in tag_genotype and "XRef" in tag_genotype.get("XRefList", {}):
+        if "XRefList" in tag_genotype and "XRef" in (tag_genotype["XRefList"] or {}):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_genotype.get("XRefList", {}).get("XRef", []))
+                for entry in cls.ensure_list((tag_genotype["XRefList"] or {}).get("XRef", []))
             ]
         comments: list[Comment] | None = None
         if "Comment" in tag_genotype:
@@ -4399,10 +4399,10 @@ class ConvertAllele(ConverterBase):
                 {"Classifications": tag_allele["Classifications"]}
             )
         xrefs: list[Xref] | None = None
-        if "XRefList" in tag_allele and "XRef" in tag_allele.get("XRefList", {}):
+        if "XRefList" in tag_allele and "XRef" in (tag_allele["XRefList"] or {}):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_allele.get("XRefList", {}).get("XRef", []))
+                for entry in cls.ensure_list((tag_allele["XRefList"] or {}).get("XRef", []))
             ]
         comments: list[Comment] | None = None
         if "Comment" in tag_allele:
@@ -4500,10 +4500,10 @@ class ConvertHaplotype(ConverterBase):
                 for entry in cls.ensure_list(tag_haplotype["FunctionalConsequence"])
             ]
         xrefs: list[Xref] | None = None
-        if "XRefList" in tag_haplotype and "XRef" in tag_haplotype.get("XRefList", {}):
+        if "XRefList" in tag_haplotype and "XRef" in (tag_haplotype["XRefList"] or {}):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_haplotype.get("XRefList", {}).get("XRef", []))
+                for entry in cls.ensure_list((tag_haplotype["XRefList"] or {}).get("XRef", []))
             ]
         comments: list[Comment] | None = None
         if "Comment" in tag_haplotype:
@@ -4672,10 +4672,10 @@ class ConvertGenotype(ConverterBase):
                 {"Classifications": tag_record["Classifications"]}
             )
         xrefs: list[Xref] | None = None
-        if "XRefList" in tag_record and "XRef" in tag_record.get("XRefList", {}):
+        if "XRefList" in tag_record and "XRef" in (tag_record["XRefList"] or {}):
             xrefs = [
                 ConvertXref.xmldict_data_to_pb({"XRef": entry})
-                for entry in cls.ensure_list(tag_record.get("XRefList", {}).get("XRef", []))
+                for entry in cls.ensure_list((tag_record["XRefList"] or {}).get("XRef", []))
             ]
         citations: list[Citation] | None = None
         if "CitationList" in tag_record and "Citation" in tag_record["CitationList"]:


### PR DESCRIPTION
Some VariationArchive records seem to have no XRef (and/or XRefList) set; return an empty default on access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced progress indicator behavior for a smoother and more responsive visual display.
  - Improved data processing to gracefully handle missing information, reducing potential errors during conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->