### PR TITLE
fix: downgrade xmltodict to v0.13 because of memory leak regression

### DIFF
--- a/clinvar_data/conversion/__init__.py
+++ b/clinvar_data/conversion/__init__.py
@@ -15,8 +15,8 @@ from clinvar_data.conversion import dict_to_pb
 from clinvar_data.conversion.normalizer import VariationArchiveNormalizer
 from clinvar_data.pbs import clinvar_public
 
-#: Total number of VariantArchive records in ClinVar on 2025-02-18: 3335626.
-TOTAL_RECORDS: int = 3_335_626
+#: Total number of VariantArchive records in ClinVar on 2025-02-28: 3437148.
+TOTAL_RECORDS: int = 3_437_148
 
 
 def convert_variation_archive(json_va: dict) -> clinvar_public.VariationArchive:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ click >=8.1.3, <9.0
 toml >=0.10.2, <0.11
 tabulate >= 0.9.0
 jsonschema >= 4.17.0, <5.0
-xmltodict >=0.13.0, <0.15
+xmltodict >=0.13.0, <0.14
 tqdm >=4.0
 protobuf >=3.20.2, <6.0
 pysam


### PR DESCRIPTION
cf. https://github.com/martinblech/xmltodict/issues/365